### PR TITLE
Add GetFirstOrDefaultAsync<TResult> method

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.UnitOfWork/IRepository.cs
+++ b/src/Microsoft.EntityFrameworkCore.UnitOfWork/IRepository.cs
@@ -110,34 +110,64 @@ namespace Microsoft.EntityFrameworkCore
                                                              CancellationToken cancellationToken = default(CancellationToken)) where TResult : class;
 
         /// <summary>
-        /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method default no-tracking query.
+        /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method defaults to a read-only, no-tracking query.
         /// </summary>
         /// <param name="predicate">A function to test each element for a condition.</param>
         /// <param name="orderBy">A function to order elements.</param>
         /// <param name="include">A function to include navigation properties</param>
-        /// <param name="disableTracking"><c>True</c> to disable changing tracking; otherwise, <c>false</c>. Default to <c>true</c>.</param>
+        /// <param name="disableTracking"><c>true</c> to disable changing tracking; otherwise, <c>false</c>. Default to <c>true</c>.</param>
         /// <returns>An <see cref="IPagedList{TEntity}"/> that contains elements that satisfy the condition specified by <paramref name="predicate"/>.</returns>
-        /// <remarks>This method default no-tracking query.</remarks>
+        /// <remarks>This method defaults to a read-only, no-tracking query.</remarks>
         TEntity GetFirstOrDefault(Expression<Func<TEntity, bool>> predicate = null,
                                   Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
                                   Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
                                   bool disableTracking = true);
 
         /// <summary>
-        /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method default no-tracking query.
+        /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method defaults to a read-only, no-tracking query.
         /// </summary>
         /// <param name="selector">The selector for projection.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
         /// <param name="orderBy">A function to order elements.</param>
         /// <param name="include">A function to include navigation properties</param>
-        /// <param name="disableTracking"><c>True</c> to disable changing tracking; otherwise, <c>false</c>. Default to <c>true</c>.</param>
+        /// <param name="disableTracking"><c>true</c> to disable changing tracking; otherwise, <c>false</c>. Default to <c>true</c>.</param>
         /// <returns>An <see cref="IPagedList{TEntity}"/> that contains elements that satisfy the condition specified by <paramref name="predicate"/>.</returns>
-        /// <remarks>This method default no-tracking query.</remarks>
+        /// <remarks>This method defaults to a read-only, no-tracking query.</remarks>
         TResult GetFirstOrDefault<TResult>(Expression<Func<TEntity, TResult>> selector,
                                            Expression<Func<TEntity, bool>> predicate = null,
                                            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
                                            Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
                                            bool disableTracking = true);
+
+        /// <summary>
+        /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method defaults to a read-only, no-tracking query.
+        /// </summary>
+        /// <param name="selector">The selector for projection.</param>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <param name="orderBy">A function to order elements.</param>
+        /// <param name="include">A function to include navigation properties</param>
+        /// <param name="disableTracking"><c>true</c> to disable changing tracking; otherwise, <c>false</c>. Default to <c>true</c>.</param>
+        /// <returns>An <see cref="IPagedList{TEntity}"/> that contains elements that satisfy the condition specified by <paramref name="predicate"/>.</returns>
+        /// <remarks>Ex: This method defaults to a read-only, no-tracking query.</remarks>
+        Task<TResult> GetFirstOrDefaultAsync<TResult>(Expression<Func<TEntity, TResult>> selector,
+            Expression<Func<TEntity, bool>> predicate = null,
+            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
+            Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
+            bool disableTracking = true);
+
+        /// <summary>
+        /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method defaults to a read-only, no-tracking query.
+        /// </summary>
+        /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <param name="orderBy">A function to order elements.</param>
+        /// <param name="include">A function to include navigation properties</param>
+        /// <param name="disableTracking"><c>true</c> to disable changing tracking; otherwise, <c>false</c>. Default to <c>true</c>.</param>
+        /// <returns>An <see cref="IPagedList{TEntity}"/> that contains elements that satisfy the condition specified by <paramref name="predicate"/>.</returns>
+        /// <remarks>Ex: This method defaults to a read-only, no-tracking query. </remarks>
+        Task<TEntity> GetFirstOrDefaultAsync(Expression<Func<TEntity, bool>> predicate = null,
+            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
+            Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
+            bool disableTracking = true);
 
         /// <summary>
         /// Uses raw SQL queries to fetch the specified <typeparamref name="TEntity" /> data.

--- a/src/Microsoft.EntityFrameworkCore.UnitOfWork/Repository.cs
+++ b/src/Microsoft.EntityFrameworkCore.UnitOfWork/Repository.cs
@@ -276,6 +276,39 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+
+        /// <inheritdoc />
+        public async Task<TEntity> GetFirstOrDefaultAsync(Expression<Func<TEntity, bool>> predicate = null,
+            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
+            Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
+            bool disableTracking = true)
+        {
+            IQueryable<TEntity> query = _dbSet;
+            if (disableTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
+            if (include != null)
+            {
+                query = include(query);
+            }
+
+            if (predicate != null)
+            {
+                query = query.Where(predicate);
+            }
+
+            if (orderBy != null)
+            {
+                return await orderBy(query).FirstOrDefaultAsync();
+            }
+            else
+            {
+                return await query.FirstOrDefaultAsync();
+            }
+        }
+
         /// <summary>
         /// Gets the first or default entity based on a predicate, orderby delegate and include delegate. This method default no-tracking query.
         /// </summary>
@@ -315,6 +348,39 @@ namespace Microsoft.EntityFrameworkCore
             else
             {
                 return query.Select(selector).FirstOrDefault();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<TResult> GetFirstOrDefaultAsync<TResult>(Expression<Func<TEntity, TResult>> selector,
+                                                  Expression<Func<TEntity, bool>> predicate = null,
+                                                  Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
+                                                  Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
+                                                  bool disableTracking = true)
+        {
+            IQueryable<TEntity> query = _dbSet;
+            if (disableTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
+            if (include != null)
+            {
+                query = include(query);
+            }
+
+            if (predicate != null)
+            {
+                query = query.Where(predicate);
+            }
+
+            if (orderBy != null)
+            {
+                return await orderBy(query).Select(selector).FirstOrDefaultAsync();
+            }
+            else
+            {
+                return await query.Select(selector).FirstOrDefaultAsync();
             }
         }
 
@@ -425,12 +491,16 @@ namespace Microsoft.EntityFrameworkCore
         public void Update(TEntity entity)
         {
             _dbSet.Update(entity);
+        }
 
-            // Shadow properties?
-            //var property = _dbContext.Entry(entity).Property("LastUpdated");
-            //if(property != null) {
-            //property.CurrentValue = DateTime.Now;
-            //}
+        /// <summary>
+        /// Updates the specified entity.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        public void UpdateAsync(TEntity entity)
+        {
+            _dbSet.Update(entity);
+
         }
 
         /// <summary>

--- a/test/Microsoft.EntityFrameworkCore.UnitOfWork.Tests/TestGetFirstOrDefaultAsync.cs
+++ b/test/Microsoft.EntityFrameworkCore.UnitOfWork.Tests/TestGetFirstOrDefaultAsync.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.UnitOfWork.Tests.Entities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.UnitOfWork.Tests
+{
+    public class TestGetFirstOrDefaultAsync
+    {
+        private static readonly InMemoryContext db;
+        
+        static TestGetFirstOrDefaultAsync()
+        {
+            db = new InMemoryContext();
+            if (db.Countries.Any())
+            {
+                db.AddRange(TestCountries);
+                db.AddRange(TestCities);
+                db.AddRange(TestTowns);
+                db.SaveChanges();
+            }
+        }
+
+
+        [Fact]
+        public async void TestGetFirstOrDefaultAsyncGetsCorrectItem()
+        {
+            var repository = new Repository<City>(db);
+            var city = await repository.GetFirstOrDefaultAsync(predicate: t => t.Name == "A");
+            Assert.NotNull(city);
+            Assert.Equal(1, city.Id);            
+        }
+
+        [Fact]
+        public async void TestGetFirstOrDefaultAsyncReturnsNullValue()
+        {
+            var repository = new Repository<City>(db);
+            var city = await repository.GetFirstOrDefaultAsync(predicate: t => t.Name == "Easy-E");
+            Assert.Null(city);            
+        }
+
+        [Fact]
+        public async void TestGetFirstOrDefaultAsyncCanInclude()
+        {
+            var repository = new Repository<City>(db);
+            var city = await repository.GetFirstOrDefaultAsync(
+                predicate: c => c.Name == "A",
+                include: source => source.Include(t => t.Towns));
+            Assert.NotNull(city);
+            Assert.NotNull(city.Towns);
+        }
+
+
+        protected static List<Country> TestCountries => new List<Country>
+        {
+            new Country {Id = 1, Name = "A"},
+            new Country {Id = 2, Name = "B"}
+        };
+
+        public static List<City> TestCities => new List<City>
+        {
+            new City { Id = 1, Name = "A", CountryId = 1},
+            new City { Id = 2, Name = "B", CountryId = 2},
+            new City { Id = 3, Name = "C", CountryId = 1},
+            new City { Id = 4, Name = "D", CountryId = 2},
+            new City { Id = 5, Name = "E", CountryId = 1},
+            new City { Id = 6, Name = "F", CountryId = 2},
+        };
+
+        public static List<Town> TestTowns => new List<Town>
+        {
+            new Town { Id = 1, Name="TownA", CityId = 1 },
+            new Town { Id = 2, Name="TownB", CityId = 2 },
+            new Town { Id = 3, Name="TownC", CityId = 3 },
+            new Town { Id = 4, Name="TownD", CityId = 4 },
+            new Town { Id = 5, Name="TownE", CityId = 5 },
+            new Town { Id = 6, Name="TownF", CityId = 6 },
+        };
+    }
+}


### PR DESCRIPTION
- Add GetFirstOrDefaultAsync() + 1 overload
- Fixed Minor spelling, grammar, and consistency issues ("This method default no-tracking query." => "This method defaults to a read-only, no-tracking query.")
- removed commented out code.
- unit tests for GetFirstOrDefaultAsync()